### PR TITLE
ENH Move exception for non-positive errors into quality

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+* :release:`0.5.0 <2015-08-31>`
+* :feature:`19` Move exception for non-positive errors from scaledata into
+  quality
+
 * :release:`0.4.0 <2015-08-30>`
 * :feature:`15` scaledata issues only warning instead of exception when rho_c
   is out of range

--- a/fssa/fssa.py
+++ b/fssa/fssa.py
@@ -116,8 +116,7 @@ def scaledata(l, rho, a, da, rho_c, nu, zeta):
     ValueError
        If `l` or `rho` is not 1-D array_like, if `a` or `da` is not 2-D
        array_like, if the shape of `a` or `da` differs from ``(l.size,
-       rho.size)``, if `da` has non-positive entries, or if `rho_c` is out of
-       range
+       rho.size)``
 
     References
     ----------
@@ -157,10 +156,6 @@ def scaledata(l, rho, a, da, rho_c, nu, zeta):
     # da should have shape (l.size, rho.size)
     if da.shape != (l.size, rho.size):
         raise ValueError("da should have shape (l.size, rho.size)")
-
-    # da should have only positive entries
-    if not np.all(da > 0.0):
-        raise ValueError("da should have only positive values")
 
     # rho_c should be float
     rho_c = float(rho_c)
@@ -353,7 +348,8 @@ def quality(x, y, dy, x_bounds=None):
     ------
     ValueError
         if not all arrays `x`, `y`, `dy` have dimension 2, or if not all arrays
-        are of the same shape, or if `x` is not sorted along rows (``axis=1``)
+        are of the same shape, or if `x` is not sorted along rows (``axis=1``),
+        or if `dy` does not have only positive entries
 
     Notes
     -----
@@ -390,6 +386,10 @@ def quality(x, y, dy, x_bounds=None):
     # x should be sorted for all system sizes l
     if not np.array_equal(x, np.sort(x, axis=1)):
         raise ValueError("x should be sorted for each system size")
+
+    # dy should have only positive entries
+    if not np.all(dy > 0.0):
+        raise ValueError("dy should have only positive values")
 
     # first dimension: system sizes l
     # second dimension: parameter values rho

--- a/fssa/test/test_fss.py
+++ b/fssa/test/test_fss.py
@@ -116,19 +116,19 @@ class TestScaleData(unittest.TestCase):
         args['da'] = np.ones(shape=(3, args['rho'].size - 1))
         self.assertRaises(ValueError, fssa.scaledata, **args)
 
-    def test_da_all_positive(self):
+    def test_no_error_if_not_da_all_positive(self):
         """
-        Test that function raises ValueError if any da is not positive
+        Test that function does not raise ValueError if any da is not positive
         """
 
         # da should have only positive entries
         args = copy.deepcopy(self.default_params)
         args['da'][1, 1] = 0.
-        self.assertRaises(ValueError, fssa.scaledata, **args)
+        fssa.scaledata(**args)
 
         args = copy.deepcopy(self.default_params)
         args['da'][1, 0] = -1.
-        self.assertRaises(ValueError, fssa.scaledata, **args)
+        fssa.scaledata(**args)
 
     def test_rho_c_float(self):
         """
@@ -751,6 +751,22 @@ class TestQuality(unittest.TestCase):
         # manipulate x at some dimension
         args[0][1, 3] = args[0][1, 1]
 
+        self.assertRaises(ValueError, fssa.quality, *args)
+
+    def test_dy_all_positive(self):
+        """
+        Test that function raises ValueError if any dy is not positive
+        """
+        orig_args = list(self.scaled_data)
+
+        # dy should have only positive entries
+        args = copy.deepcopy(orig_args)
+        args[2][1, 1] = 0.
+        self.assertRaises(ValueError, fssa.quality, *args)
+
+        args = copy.deepcopy(orig_args)
+        assert args[2][1, 1] != 0
+        args[2][1, 0] = -1.
         self.assertRaises(ValueError, fssa.quality, *args)
 
     def test_zero_quality(self):


### PR DESCRIPTION
As scaledata can still work with non-positive errors.

Closes #19
